### PR TITLE
feat: 添加 UI Lock 机制防止并发请求时的 UI 操作冲突

### DIFF
--- a/src/backend/adapter/chatgpt.js
+++ b/src/backend/adapter/chatgpt.js
@@ -15,6 +15,7 @@ import {
     waitApiResponse,
     useContextDownload
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -31,71 +32,76 @@ const INPUT_SELECTOR = '.ProseMirror';
  * @returns {Promise<{image?: string, error?: string}>}
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, instanceName } = context;
     const sendBtnLocator = page.getByRole('button', { name: 'Send prompt' });
 
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, INPUT_SELECTOR, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, INPUT_SELECTOR, { click: false });
 
-        // 2. 上传图片
-        if (imgPaths && imgPaths.length > 0) {
+            // 2. 上传图片
+            if (imgPaths && imgPaths.length > 0) {
 
-            const expectedUploads = imgPaths.length;
-            let uploadedCount = 0;
-            let processedCount = 0;
-            logger.info('适配器', `开始上传 ${expectedUploads} 张图片...`, meta);
-            logger.debug('适配器', '点击添加文件按钮...', meta);
-            const addFilesBtn = page.getByRole('button', { name: 'Add files and more' });
+                const expectedUploads = imgPaths.length;
+                let uploadedCount = 0;
+                let processedCount = 0;
+                logger.info('适配器', `开始上传 ${expectedUploads} 张图片...`, meta);
+                logger.debug('适配器', '点击添加文件按钮...', meta);
+                const addFilesBtn = page.getByRole('button', { name: 'Add files and more' });
 
-            await uploadFilesViaChooser(page, addFilesBtn, imgPaths, {
-                uploadValidator: (response) => {
-                    const url = response.url();
-                    if (response.status() === 200) {
-                        // 上传请求
-                        if (url.includes('backend-api/files') && !url.includes('process_upload_stream')) {
-                            uploadedCount++;
-                            logger.debug('适配器', `图片上传进度: ${uploadedCount}/${expectedUploads}`, meta);
-                            return false;
-                        }
-                        // 处理完成请求
-                        if (url.includes('backend-api/files/process_upload_stream')) {
-                            processedCount++;
-                            logger.info('适配器', `图片处理进度: ${processedCount}/${expectedUploads}`, meta);
+                await uploadFilesViaChooser(page, addFilesBtn, imgPaths, {
+                    uploadValidator: (response) => {
+                        const url = response.url();
+                        if (response.status() === 200) {
+                            // 上传请求
+                            if (url.includes('backend-api/files') && !url.includes('process_upload_stream')) {
+                                uploadedCount++;
+                                logger.debug('适配器', `图片上传进度: ${uploadedCount}/${expectedUploads}`, meta);
+                                return false;
+                            }
+                            // 处理完成请求
+                            if (url.includes('backend-api/files/process_upload_stream')) {
+                                processedCount++;
+                                logger.info('适配器', `图片处理进度: ${processedCount}/${expectedUploads}`, meta);
 
-                            if (processedCount >= expectedUploads) {
-                                return true;
+                                if (processedCount >= expectedUploads) {
+                                    return true;
+                                }
                             }
                         }
+                        return false;
                     }
-                    return false;
-                }
-            }, meta);
-            logger.info('适配器', '图片上传完成', meta);
-        }
+                }, meta);
+                logger.info('适配器', '图片上传完成', meta);
+            }
 
-        // 3. 输入提示词
-        logger.info('适配器', '输入提示词...', meta);
-        await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
-        await humanType(page, INPUT_SELECTOR, prompt);
+            // 3. 输入提示词
+            logger.info('适配器', '输入提示词...', meta);
+            await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
+            await humanType(page, INPUT_SELECTOR, prompt);
 
-        // 4. 发送提示词
-        logger.debug('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
+            // 4. 发送提示词（点击后立即释放锁）
+            logger.debug('适配器', '发送提示词...', meta);
+            await safeClick(page, sendBtnLocator, { bias: 'button' });
 
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 5. 等待 API 响应（不需要锁，可以并行）
         logger.info('适配器', '等待生成结果...', meta);
 
-        // 5. 等待 conversation API 返回
         let conversationResponse;
         try {
             conversationResponse = await waitApiResponse(page, {
                 urlMatch: 'backend-api/f/conversation',
                 method: 'POST',
-                timeout: waitTimeout,  // 图片生成可能较慢
+                timeout: 120000,  // 图片生成可能较慢
                 meta
             });
         } catch (e) {
@@ -145,7 +151,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
                 } catch {
                     return false;
                 }
-            }, { timeout: waitTimeout });
+            }, { timeout: 120000 });
         } catch (e) {
             const pageError = normalizePageError(e, meta);
             if (pageError) return pageError;
@@ -160,10 +166,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
         logger.info('适配器', '正在下载图片...', meta);
 
         // 7. 使用 useContextDownload 下载图片
-        const imgDlCfg = config?.backend?.pool?.failover || {};
-        const result = await useContextDownload(downloadUrl, page, {
-            retries: imgDlCfg.imgDlRetry ? (imgDlCfg.imgDlRetryMaxRetries || 2) : 0
-        });
+        const result = await useContextDownload(downloadUrl, page);
         if (result.error) {
             logger.error('适配器', result.error, meta);
             return result;

--- a/src/backend/adapter/chatgpt_text.js
+++ b/src/backend/adapter/chatgpt_text.js
@@ -13,6 +13,7 @@ import {
     waitForInput,
     gotoWithCheck
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -80,72 +81,79 @@ async function selectModel(page, codeName, meta = {}) {
  * @returns {Promise<{text?: string, error?: string}>}
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
+    const { page, instanceName, config } = context;
     const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
     const sendBtnLocator = page.getByRole('button', { name: 'Send prompt' });
 
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, INPUT_SELECTOR, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, INPUT_SELECTOR, { click: false });
 
-        // 2. 选择模型
-        const modelConfig = manifest.models.find(m => m.id === modelId);
-        const targetModel = modelConfig?.codeName || modelId;
-        if (targetModel) {
-            await selectModel(page, targetModel, meta);
-        }
+            // 2. 选择模型
+            const modelConfig = manifest.models.find(m => m.id === modelId);
+            const targetModel = modelConfig?.codeName || modelId;
+            if (targetModel) {
+                await selectModel(page, targetModel, meta);
+            }
 
-        // 3. 上传图片 (双击 Add files and more 按钮)
-        if (imgPaths && imgPaths.length > 0) {
-            logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
-            const expectedUploads = imgPaths.length;
-            let uploadedCount = 0;
-            let processedCount = 0;
+            // 3. 上传图片 (双击 Add files and more 按钮)
+            if (imgPaths && imgPaths.length > 0) {
+                logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
+                const expectedUploads = imgPaths.length;
+                let uploadedCount = 0;
+                let processedCount = 0;
 
-            logger.debug('适配器', '双击添加文件按钮...', meta);
-            const addFilesBtn = page.getByRole('button', { name: 'Add files and more' });
+                logger.debug('适配器', '双击添加文件按钮...', meta);
+                const addFilesBtn = page.getByRole('button', { name: 'Add files and more' });
 
-            await uploadFilesViaChooser(page, addFilesBtn, imgPaths, {
-                clickAction: 'dblclick',  // 使用双击
-                uploadValidator: (response) => {
-                    const url = response.url();
-                    if (response.status() === 200) {
-                        // 上传请求
-                        if (url.includes('backend-api/files') && !url.includes('process_upload_stream')) {
-                            uploadedCount++;
-                            logger.debug('适配器', `图片上传进度: ${uploadedCount}/${expectedUploads}`, meta);
-                            return false;
-                        }
-                        // 处理完成请求
-                        if (url.includes('backend-api/files/process_upload_stream')) {
-                            processedCount++;
-                            logger.info('适配器', `图片处理进度: ${processedCount}/${expectedUploads}`, meta);
+                await uploadFilesViaChooser(page, addFilesBtn, imgPaths, {
+                    clickAction: 'dblclick',  // 使用双击
+                    uploadValidator: (response) => {
+                        const url = response.url();
+                        if (response.status() === 200) {
+                            // 上传请求
+                            if (url.includes('backend-api/files') && !url.includes('process_upload_stream')) {
+                                uploadedCount++;
+                                logger.debug('适配器', `图片上传进度: ${uploadedCount}/${expectedUploads}`, meta);
+                                return false;
+                            }
+                            // 处理完成请求
+                            if (url.includes('backend-api/files/process_upload_stream')) {
+                                processedCount++;
+                                logger.info('适配器', `图片处理进度: ${processedCount}/${expectedUploads}`, meta);
 
-                            if (processedCount >= expectedUploads) {
-                                return true;
+                                if (processedCount >= expectedUploads) {
+                                    return true;
+                                }
                             }
                         }
+                        return false;
                     }
-                    return false;
-                }
-            }, meta);
-        }
+                }, meta);
+            }
 
-        // 3. 输入提示词
-        logger.info('适配器', '输入提示词...', meta);
-        await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
-        await humanType(page, INPUT_SELECTOR, prompt);
+            // 4. 输入提示词
+            logger.info('适配器', '输入提示词...', meta);
+            await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
+            await humanType(page, INPUT_SELECTOR, prompt);
 
-        // 5. 发送提示词
-        logger.debug('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
+            // 5. 发送提示词（点击后立即释放锁）
+            logger.debug('适配器', '发送提示词...', meta);
+            await safeClick(page, sendBtnLocator, { bias: 'button' });
 
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 6. 等待 API 响应（不需要锁，可以并行）
         logger.info('适配器', '等待生成结果...', meta);
 
-        // 6. 监听 conversation API 的 SSE 流，解析文本内容
+        // 监听 conversation API 的 SSE 流，解析文本内容
         logger.info('适配器', '监听 SSE 流获取文本...', meta);
 
         let textContent = '';

--- a/src/backend/adapter/deepseek_text.js
+++ b/src/backend/adapter/deepseek_text.js
@@ -12,6 +12,7 @@ import {
     waitForInput,
     gotoWithCheck
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -82,86 +83,74 @@ async function configureModel(page, modelConfig, meta = {}) {
  * @returns {Promise<{text?: string, error?: string}>}
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, instanceName } = context;
+
+    // 用于响应监听
+    let textContent = '';
+    let isComplete = false;
+    let isCollecting = false;  // 当前最后一个 fragment 是否为 RESPONSE 类型
+    let isResolved = false;
+    let resultPromise = null;
+    let handleResponse = null;
+    let timeoutId = null;
 
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, INPUT_SELECTOR, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, INPUT_SELECTOR, { click: false });
 
-        // 2. 配置模型功能 (thinking / search)
-        const modelConfig = manifest.models.find(m => m.id === modelId);
-        if (modelConfig) {
-            await configureModel(page, modelConfig, meta);
-        }
+            // 2. 配置模型功能 (thinking / search)
+            const modelConfig = manifest.models.find(m => m.id === modelId);
+            if (modelConfig) {
+                await configureModel(page, modelConfig, meta);
+            }
 
-        // 3. 输入提示词
-        logger.info('适配器', '输入提示词...', meta);
-        await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
-        await humanType(page, INPUT_SELECTOR, prompt);
-        await sleep(300, 500);
+            // 3. 输入提示词
+            logger.info('适配器', '输入提示词...', meta);
+            await safeClick(page, INPUT_SELECTOR, { bias: 'input' });
+            await humanType(page, INPUT_SELECTOR, prompt);
+            await sleep(300, 500);
 
-        // 4. 先启动 API 监听
-        logger.debug('适配器', '启动 API 监听...', meta);
+            // 4. 设置 SSE 监听（在发送前设置）
+            logger.debug('适配器', '启动 SSE 监听...', meta);
 
-        let textContent = '';
-        let isComplete = false;
-        let isCollecting = false;  // 当前最后一个 fragment 是否为 RESPONSE 类型
+            resultPromise = new Promise((resolve, reject) => {
+                timeoutId = setTimeout(() => {
+                    if (!isResolved) {
+                        isResolved = true;
+                        reject(new Error('API_TIMEOUT: 响应超时 (120秒)'));
+                    }
+                }, 120000);
 
-        const responsePromise = page.waitForResponse(async (response) => {
-            const url = response.url();
-            if (!url.includes('chat/completion')) return false;
-            if (response.request().method() !== 'POST') return false;
-            if (response.status() !== 200) return false;
-
-            try {
-                const body = await response.text();
-                const lines = body.split('\n');
-
-                for (const line of lines) {
-                    // 跳过事件行和空行
-                    if (line.startsWith('event:') || !line.startsWith('data:')) continue;
-
-                    const dataStr = line.slice(5).trim();
-                    if (!dataStr || dataStr === '{}') continue;
-
+                handleResponse = async (response) => {
                     try {
-                        const data = JSON.parse(dataStr);
+                        const url = response.url();
+                        if (!url.includes('chat/completion')) return;
+                        if (response.request().method() !== 'POST') return;
+                        if (response.status() !== 200) return;
 
-                        // --- 处理 fragment 列表变更，更新 isCollecting 状态 ---
+                        const body = await response.text();
+                        const lines = body.split('\n');
 
-                        // 初始响应中可能已有 fragments (如 SEARCH / RESPONSE)
-                        if (data.v?.response?.fragments && Array.isArray(data.v.response.fragments)) {
-                            for (const fragment of data.v.response.fragments) {
-                                if (fragment.type === 'RESPONSE') {
-                                    isCollecting = true;
-                                    if (fragment.content) textContent += fragment.content;
-                                } else {
-                                    isCollecting = false;
-                                }
-                            }
-                        }
+                        for (const line of lines) {
+                            // 跳过事件行和空行
+                            if (line.startsWith('event:') || !line.startsWith('data:')) continue;
 
-                        // fragments APPEND - 新增 fragment (非 BATCH)
-                        if (data.p === 'response/fragments' && data.o === 'APPEND' && Array.isArray(data.v)) {
-                            for (const fragment of data.v) {
-                                if (fragment.type === 'RESPONSE') {
-                                    isCollecting = true;
-                                    if (fragment.content) textContent += fragment.content;
-                                } else {
-                                    isCollecting = false;
-                                }
-                            }
-                        }
+                            const dataStr = line.slice(5).trim();
+                            if (!dataStr || dataStr === '{}') continue;
 
-                        // BATCH 操作中的 fragments
-                        if (data.o === 'BATCH' && data.p === 'response' && Array.isArray(data.v)) {
-                            for (const item of data.v) {
-                                if (item.p === 'fragments' && item.o === 'APPEND' && Array.isArray(item.v)) {
-                                    for (const fragment of item.v) {
+                            try {
+                                const data = JSON.parse(dataStr);
+
+                                // --- 处理 fragment 列表变更，更新 isCollecting 状态 ---
+
+                                // 初始响应中可能已有 fragments (如 SEARCH / RESPONSE)
+                                if (data.v?.response?.fragments && Array.isArray(data.v.response.fragments)) {
+                                    for (const fragment of data.v.response.fragments) {
                                         if (fragment.type === 'RESPONSE') {
                                             isCollecting = true;
                                             if (fragment.content) textContent += fragment.content;
@@ -170,61 +159,93 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
                                         }
                                     }
                                 }
-                                // 检查是否完成 (quasi_status 或 status)
-                                if ((item.p === 'status' || item.p === 'quasi_status') && item.v === 'FINISHED') {
+
+                                // fragments APPEND - 新增 fragment (非 BATCH)
+                                if (data.p === 'response/fragments' && data.o === 'APPEND' && Array.isArray(data.v)) {
+                                    for (const fragment of data.v) {
+                                        if (fragment.type === 'RESPONSE') {
+                                            isCollecting = true;
+                                            if (fragment.content) textContent += fragment.content;
+                                        } else {
+                                            isCollecting = false;
+                                        }
+                                    }
+                                }
+
+                                // BATCH 操作中的 fragments
+                                if (data.o === 'BATCH' && data.p === 'response' && Array.isArray(data.v)) {
+                                    for (const item of data.v) {
+                                        if (item.p === 'fragments' && item.o === 'APPEND' && Array.isArray(item.v)) {
+                                            for (const fragment of item.v) {
+                                                if (fragment.type === 'RESPONSE') {
+                                                    isCollecting = true;
+                                                    if (fragment.content) textContent += fragment.content;
+                                                } else {
+                                                    isCollecting = false;
+                                                }
+                                            }
+                                        }
+                                        // 检查是否完成 (quasi_status 或 status)
+                                        if ((item.p === 'status' || item.p === 'quasi_status') && item.v === 'FINISHED') {
+                                            isComplete = true;
+                                        }
+                                    }
+                                }
+
+                                // --- 处理文本内容追加 ---
+
+                                // 带路径的 content 操作 (如 response/fragments/-1/content)
+                                if (data.p && typeof data.v === 'string') {
+                                    const match = data.p.match(/response\/fragments\/(-?\d+)\/content/);
+                                    if (match && isCollecting) {
+                                        textContent += data.v;
+                                    }
+                                }
+
+                                // 纯文本追加 (只有 v 字符串，没有 p 和 o)
+                                if (data.v && typeof data.v === 'string' && !data.p && !data.o) {
+                                    if (isCollecting) {
+                                        textContent += data.v;
+                                    }
+                                }
+
+                                // --- 检查完成信号 ---
+
+                                // 独立的 status SET 操作
+                                if (data.p === 'response/status' && data.o === 'SET' && data.v === 'FINISHED') {
                                     isComplete = true;
                                 }
+                            } catch {
+                                // 忽略解析错误
                             }
                         }
 
-                        // --- 处理文本内容追加 ---
-
-                        // 带路径的 content 操作 (如 response/fragments/-1/content)
-                        if (data.p && typeof data.v === 'string') {
-                            const match = data.p.match(/response\/fragments\/(-?\d+)\/content/);
-                            if (match && isCollecting) {
-                                textContent += data.v;
-                            }
+                        // 完成时 resolve
+                        if (isComplete && !isResolved) {
+                            isResolved = true;
+                            clearTimeout(timeoutId);
+                            page.off('response', handleResponse);
+                            resolve();
                         }
-
-                        // 纯文本追加 (只有 v 字符串，没有 p 和 o)
-                        if (data.v && typeof data.v === 'string' && !data.p && !data.o) {
-                            if (isCollecting) {
-                                textContent += data.v;
-                            }
-                        }
-
-                        // --- 检查完成信号 ---
-
-                        // 独立的 status SET 操作
-                        if (data.p === 'response/status' && data.o === 'SET' && data.v === 'FINISHED') {
-                            isComplete = true;
-                        }
-                    } catch {
+                    } catch (e) {
                         // 忽略解析错误
                     }
-                }
+                };
 
-                return isComplete;
-            } catch {
-                return false;
-            }
-        }, { timeout: waitTimeout });
+                page.on('response', handleResponse);
+            });
 
-        // 5. 发送提示词
-        logger.debug('适配器', '发送提示词...', meta);
-        await page.keyboard.press('Enter');
+            // 5. 发送提示词
+            logger.debug('适配器', '发送提示词...', meta);
+            await page.keyboard.press('Enter');
 
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 6. 等待响应（不需要锁，可以并行）
         logger.info('适配器', '等待生成结果...', meta);
-
-        // 6. 等待 API 响应
-        try {
-            await responsePromise;
-        } catch (e) {
-            const pageError = normalizePageError(e, meta);
-            if (pageError) return pageError;
-            throw e;
-        }
+        await resultPromise;
 
         if (!textContent || textContent.trim() === '') {
             logger.warn('适配器', '回复内容为空', meta);

--- a/src/backend/adapter/gemini.js
+++ b/src/backend/adapter/gemini.js
@@ -16,6 +16,7 @@ import {
     waitApiResponse,
     useContextDownload
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -32,90 +33,92 @@ const TARGET_URL = 'https://gemini.google.com/app?hl=en';
  * @returns {Promise<{image?: string, error?: string}>}
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, instanceName } = context;
     const inputLocator = page.getByRole('textbox');
     const sendBtnLocator = page.getByRole('button', { name: 'Send message' });
 
+    // 检测是否是视频模型
+    const isVideoModel = modelId && modelId.startsWith('veo-');
+
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, inputLocator, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, inputLocator, { click: false });
 
-        // 2. 上传图片
-        if (imgPaths && imgPaths.length > 0) {
-            logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
-            logger.debug('适配器', '点击加号按钮...', meta);
-            const uploadMenuBtn = page.getByRole('button', { name: 'Open upload file menu' });
-            await safeClick(page, uploadMenuBtn, { bias: 'button' });
+            // 2. 上传图片
+            if (imgPaths && imgPaths.length > 0) {
+                logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
+                logger.debug('适配器', '点击加号按钮...', meta);
+                const uploadMenuBtn = page.getByRole('button', { name: 'Open upload file menu' });
+                await safeClick(page, uploadMenuBtn, { bias: 'button' });
 
-            // 使用公共函数上传文件
-            const uploadFilesBtn = page.getByRole('menuitem', { name: /Upload files/ });
-            await uploadFilesViaChooser(page, uploadFilesBtn, imgPaths, {
-                uploadValidator: (response) => {
-                    const url = response.url();
-                    return response.status() === 200 &&
-                        url.includes('google.com/upload/') &&
-                        url.includes('upload_id=');
-                }
-            }, meta);
-            logger.info('适配器', '图片上传完成', meta);
-        }
-
-        // 3. 点击 Tools 按钮启用图片/视频生成
-        logger.debug('适配器', '点击 Tools 按钮...', meta);
-        const toolsBtn = page.getByRole('button', { name: 'Tools' });
-        await safeClick(page, toolsBtn, { bias: 'button' });
-
-        // 检测是否是视频模型
-        const isVideoModel = modelId && modelId.startsWith('veo-');
-
-        // 5. 点击 Create images / Create videos 按钮
-        if (isVideoModel) {
-            logger.debug('适配器', '点击 Create video 按钮...', meta);
-            const createVideosBtn = page.getByRole('menuitemcheckbox', { name: 'Create video' });
-
-            // 检查按钮是否存在（有些账号可能没有视频生成功能）
-            const btnCount = await createVideosBtn.count();
-            if (btnCount === 0) {
-                logger.error('适配器', '未找到 Create videos 按钮，该账号可能不支持视频生成', meta);
-                return { error: '该账号不支持视频生成功能 (未找到 Create video 按钮)' };
+                // 使用公共函数上传文件
+                const uploadFilesBtn = page.getByRole('menuitem', { name: /Upload files/ });
+                await uploadFilesViaChooser(page, uploadFilesBtn, imgPaths, {
+                    uploadValidator: (response) => {
+                        const url = response.url();
+                        return response.status() === 200 &&
+                            url.includes('google.com/upload/') &&
+                            url.includes('upload_id=');
+                    }
+                }, meta);
+                logger.info('适配器', '图片上传完成', meta);
             }
 
-            await safeClick(page, createVideosBtn, { bias: 'button' });
-        } else {
-            logger.debug('适配器', '点击 Create image 按钮...', meta);
-            const createImagesBtn = page.getByRole('menuitemcheckbox', { name: 'Create image' });
-            await safeClick(page, createImagesBtn, { bias: 'button' });
-        }
+            // 3. 输入提示词
+            logger.info('适配器', '输入提示词...', meta);
+            await safeClick(page, inputLocator, { bias: 'input' });
+            await humanType(page, inputLocator, prompt);
 
-        // 4. 输入提示词
-        logger.info('适配器', '输入提示词...', meta);
-        await sleep(300, 500);
-        await safeClick(page, inputLocator, { bias: 'input' });
-        await humanType(page, inputLocator, prompt);
+            // 4. 点击 Tools 按钮启用图片/视频生成
+            logger.debug('适配器', '点击 Tools 按钮...', meta);
+            const toolsBtn = page.getByRole('button', { name: 'Tools' });
+            await safeClick(page, toolsBtn, { bias: 'button' });
 
-        // 6. 先启动 API 监听
+            // 5. 点击 Create images / Create videos 按钮
+            if (isVideoModel) {
+                logger.debug('适配器', '点击 Create video 按钮...', meta);
+                const createVideosBtn = page.getByRole('menuitemcheckbox', { name: 'Create video' });
+
+                // 检查按钮是否存在（有些账号可能没有视频生成功能）
+                const btnCount = await createVideosBtn.count();
+                if (btnCount === 0) {
+                    logger.error('适配器', '未找到 Create videos 按钮，该账号可能不支持视频生成', meta);
+                    throw new Error('该账号不支持视频生成功能 (未找到 Create video 按钮)');
+                }
+
+                await safeClick(page, createVideosBtn, { bias: 'button' });
+            } else {
+                logger.debug('适配器', '点击 Create image 按钮...', meta);
+                const createImagesBtn = page.getByRole('menuitemcheckbox', { name: 'Create image' });
+                await safeClick(page, createImagesBtn, { bias: 'button' });
+            }
+
+            // 6. 发送提示词（点击后立即释放锁）
+            logger.info('适配器', '发送提示词...', meta);
+            await safeClick(page, sendBtnLocator, { bias: 'button' });
+
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 7. 等待 API 响应（不需要锁，可以并行）
         logger.debug('适配器', '启动 API 监听...', meta);
-        const streamApiResponsePromise = waitApiResponse(page, {
-            urlMatch: 'assistant.lamda.BardFrontendService/StreamGenerate',
-            method: 'POST',
-            timeout: waitTimeout,
-            meta
-        });
-
-        // 7. 发送提示词
-        logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
-
         logger.info('适配器', '等待生成结果...', meta);
 
         // 8. 等待 StreamGenerate API
         let streamApiResponse;
         try {
-            streamApiResponse = await streamApiResponsePromise;
+            streamApiResponse = await waitApiResponse(page, {
+                urlMatch: 'assistant.lamda.BardFrontendService/StreamGenerate',
+                method: 'POST',
+                timeout: 120000,
+                meta
+            });
         } catch (e) {
             const pageError = normalizePageError(e, meta);
             if (pageError) return pageError;
@@ -129,7 +132,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
             return { error: `API 返回错误: ${httpError.error}` };
         }
 
-        // 8. 等待图片/视频响应
+        // 9. 等待图片/视频响应
         if (isVideoModel) {
             // 视频模式：等待视频下载链接
             logger.info('适配器', '生成请求成功，等待视频...', meta);
@@ -140,7 +143,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
                     urlMatch: 'contribution.usercontent.google.com/download',
                     urlContains: 'filename=video.mp4',
                     method: 'GET',
-                    timeout: waitTimeout,
+                    timeout: 180000,  // 视频生成可能更慢
                     meta
                 });
             } catch (e) {
@@ -179,10 +182,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
             logger.info('适配器', `找到 ${imageUrls.length} 张图片，开始下载...`, meta);
 
             // 使用封装的下载函数
-            const imgDlCfg = config?.backend?.pool?.failover || {};
-            const result = await useContextDownload(imageUrl, page, {
-                retries: imgDlCfg.imgDlRetry ? (imgDlCfg.imgDlRetryMaxRetries || 2) : 0
-            });
+            const result = await useContextDownload(imageUrl, page);
             if (result.error) {
                 logger.error('适配器', result.error, meta);
                 return result;

--- a/src/backend/adapter/gemini_text.js
+++ b/src/backend/adapter/gemini_text.js
@@ -15,6 +15,7 @@ import {
     gotoWithCheck,
     waitApiResponse
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -30,142 +31,144 @@ const TARGET_URL = 'https://gemini.google.com/app?hl=en';
  * @returns {Promise<{text?: string, error?: string}>}
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, instanceName } = context;
     const inputLocator = page.getByRole('textbox');
     const sendBtnLocator = page.getByRole('button', { name: 'Send message' });
 
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, inputLocator, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, inputLocator, { click: false });
 
-        // 2. 上传图片
-        if (imgPaths && imgPaths.length > 0) {
-            logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
-            logger.debug('适配器', '点击加号按钮...', meta);
-            const uploadMenuBtn = page.getByRole('button', { name: 'Open upload file menu' });
-            await safeClick(page, uploadMenuBtn, { bias: 'button' });
+            // 2. 上传图片
+            if (imgPaths && imgPaths.length > 0) {
+                logger.info('适配器', `开始上传 ${imgPaths.length} 张图片...`, meta);
+                logger.debug('适配器', '点击加号按钮...', meta);
+                const uploadMenuBtn = page.getByRole('button', { name: 'Open upload file menu' });
+                await safeClick(page, uploadMenuBtn, { bias: 'button' });
 
-            const uploadFilesBtn = page.getByRole('menuitem', { name: /Upload files/ });
-            await uploadFilesViaChooser(page, uploadFilesBtn, imgPaths, {
-                uploadValidator: (response) => {
-                    const url = response.url();
-                    return response.status() === 200 &&
-                        url.includes('google.com/upload/') &&
-                        url.includes('upload_id=');
-                }
-            }, meta);
-            logger.info('适配器', '图片上传完成', meta);
-        }
-
-        // 3. 输入提示词
-        logger.info('适配器', '输入提示词...', meta);
-        await safeClick(page, inputLocator, { bias: 'input' });
-        await humanType(page, inputLocator, prompt);
-
-        // 4. 选择模型
-        if (modelId) {
-            try {
-                logger.debug('适配器', `准备选择模型: ${modelId}`, meta);
-
-                // 点击输入框确保焦点
-                await inputLocator.focus();
-                await sleep(300, 500);
-
-                // 按 3 次 Tab 键到达模型选择按钮
-                await page.keyboard.press('Tab');
-                await sleep(100, 200);
-                await page.keyboard.press('Tab');
-                await sleep(100, 200);
-                await page.keyboard.press('Tab');
-                await sleep(100, 200);
-
-                // 按回车打开模型菜单
-                await page.keyboard.press('Enter');
-                await sleep(300, 500);
-
-                // 获取所有 menuitem 选项的文本
-                const menuItemsLocator = page.getByRole('menuitem');
-                const menuItemsCount = await menuItemsLocator.count();
-
-                if (menuItemsCount === 0) {
-                    logger.warn('适配器', '未找到模型选项，使用默认模型', meta);
-                } else {
-                    // 获取所有选项的文本（去除前后空白）
-                    const itemTexts = await menuItemsLocator.allTextContents();
-
-                    logger.debug('适配器', `可用模型选项: [${itemTexts.map(t => t.trim()).join('], [')}]`, meta);
-
-                    // 判断是否有 Pro 选项
-                    const hasPro = itemTexts.some(text => text.trim().startsWith('Pro'));
-
-                    // 确定要选择的目标选项文本前缀
-                    let targetPrefix = null;
-
-                    if (hasPro) {
-                        // 有 Pro 选项的情况
-                        if (modelId === 'gemini-3.1-pro') {
-                            targetPrefix = 'Pro';
-                        } else if (modelId === 'gemini-3.1-flash-thinking') {
-                            targetPrefix = 'Thinking';
-                        } else {
-                            targetPrefix = 'Fast';
-                        }
-                    } else {
-                        // 没有 Pro 选项的情况
-                        if (modelId === 'gemini-3.1-pro' || modelId === 'gemini-3.1-flash-thinking') {
-                            targetPrefix = 'Thinking';
-                        } else {
-                            targetPrefix = 'Fast';
-                        }
+                const uploadFilesBtn = page.getByRole('menuitem', { name: /Upload files/ });
+                await uploadFilesViaChooser(page, uploadFilesBtn, imgPaths, {
+                    uploadValidator: (response) => {
+                        const url = response.url();
+                        return response.status() === 200 &&
+                            url.includes('google.com/upload/') &&
+                            url.includes('upload_id=');
                     }
-
-                    logger.debug('适配器', `目标模型前缀: "${targetPrefix}"`, meta);
-
-                    // 使用 locator 直接定位目标选项（避免缓存元素引用导致 detached 错误）
-                    const targetItem = menuItemsLocator.filter({ hasText: new RegExp(`^\\s*${targetPrefix}`) }).first();
-
-                    if (await targetItem.count() > 0) {
-                        const selectedText = (await targetItem.textContent() || '').trim();
-                        await safeClick(page, targetItem, { bias: 'button' });
-                        logger.info('适配器', `已选择模型: "${selectedText}"`, meta);
-                    } else {
-                        logger.warn('适配器', `未找到匹配的模型选项 (${targetPrefix})，使用默认模型`, meta);
-                        // 按 Escape 关闭菜单
-                        await page.keyboard.press('Escape');
-                    }
-                }
-            } catch (e) {
-                logger.warn('适配器', `模型选择失败: ${e.message}，继续使用默认模型`, meta);
-                // 尝试关闭可能打开的菜单
-                try {
-                    await page.keyboard.press('Escape');
-                } catch { }
+                }, meta);
+                logger.info('适配器', '图片上传完成', meta);
             }
-        }
 
-        // 5. 先启动 API 监听
+            // 3. 输入提示词
+            logger.info('适配器', '输入提示词...', meta);
+            await safeClick(page, inputLocator, { bias: 'input' });
+            await humanType(page, inputLocator, prompt);
+
+            // 4. 选择模型
+            if (modelId) {
+                try {
+                    logger.debug('适配器', `准备选择模型: ${modelId}`, meta);
+
+                    // 点击输入框确保焦点
+                    await inputLocator.focus();
+                    await sleep(300, 500);
+
+                    // 按 3 次 Tab 键到达模型选择按钮
+                    await page.keyboard.press('Tab');
+                    await sleep(100, 200);
+                    await page.keyboard.press('Tab');
+                    await sleep(100, 200);
+                    await page.keyboard.press('Tab');
+                    await sleep(100, 200);
+
+                    // 按回车打开模型菜单
+                    await page.keyboard.press('Enter');
+                    await sleep(300, 500);
+
+                    // 获取所有 menuitemradio 选项的文本
+                    const menuItemsLocator = page.getByRole('menuitemradio');
+                    const menuItemsCount = await menuItemsLocator.count();
+
+                    if (menuItemsCount === 0) {
+                        logger.warn('适配器', '未找到模型选项，使用默认模型', meta);
+                    } else {
+                        // 获取所有选项的文本（去除前后空白）
+                        const itemTexts = await menuItemsLocator.allTextContents();
+
+                        logger.debug('适配器', `可用模型选项: [${itemTexts.map(t => t.trim()).join('], [')}]`, meta);
+
+                        // 判断是否有 Pro 选项
+                        const hasPro = itemTexts.some(text => text.trim().startsWith('Pro'));
+
+                        // 确定要选择的目标选项文本前缀
+                        let targetPrefix = null;
+
+                        if (hasPro) {
+                            // 有 Pro 选项的情况
+                            if (modelId === 'gemini-3-pro' || modelId === 'gemini-exp-1206') {
+                                targetPrefix = 'Pro';
+                            } else if (modelId === 'gemini-3-flash' || modelId === 'gemini-2.0-flash-exp') {
+                                targetPrefix = 'Thinking';
+                            } else {
+                                targetPrefix = 'Fast';
+                            }
+                        } else {
+                            // 没有 Pro 选项的情况
+                            if (modelId === 'gemini-3-pro' || modelId === 'gemini-exp-1206') {
+                                targetPrefix = 'Thinking';
+                            } else {
+                                targetPrefix = 'Fast';
+                            }
+                        }
+
+                        logger.debug('适配器', `目标模型前缀: "${targetPrefix}"`, meta);
+
+                        // 使用 locator 直接定位目标选项（避免缓存元素引用导致 detached 错误）
+                        const targetItem = menuItemsLocator.filter({ hasText: new RegExp(`^\\s*${targetPrefix}`) }).first();
+
+                        if (await targetItem.count() > 0) {
+                            const selectedText = (await targetItem.textContent() || '').trim();
+                            await safeClick(page, targetItem, { bias: 'button' });
+                            logger.info('适配器', `已选择模型: "${selectedText}"`, meta);
+                        } else {
+                            logger.warn('适配器', `未找到匹配的模型选项 (${targetPrefix})，使用默认模型`, meta);
+                            // 按 Escape 关闭菜单
+                            await page.keyboard.press('Escape');
+                        }
+                    }
+                } catch (e) {
+                    logger.warn('适配器', `模型选择失败: ${e.message}，继续使用默认模型`, meta);
+                    // 尝试关闭可能打开的菜单
+                    try {
+                        await page.keyboard.press('Escape');
+                    } catch { }
+                }
+            }
+
+            // 5. 发送提示词（点击后立即释放锁）
+            logger.info('适配器', '发送提示词...', meta);
+            await safeClick(page, sendBtnLocator, { bias: 'button' });
+
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 6. 等待 API 响应（不需要锁，可以并行）
         logger.debug('适配器', '启动 API 监听...', meta);
-        const apiResponsePromise = waitApiResponse(page, {
-            urlMatch: 'assistant.lamda.BardFrontendService/StreamGenerate',
-            method: 'POST',
-            timeout: waitTimeout,
-            meta
-        });
-
-        // 6. 发送提示词
-        logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
-
         logger.info('适配器', '等待生成结果...', meta);
 
-        // 7. 等待 API 响应
         let apiResponse;
         try {
-            apiResponse = await apiResponsePromise;
+            apiResponse = await waitApiResponse(page, {
+                urlMatch: 'assistant.lamda.BardFrontendService/StreamGenerate',
+                method: 'POST',
+                timeout: 120000,
+                meta
+            });
         } catch (e) {
             const pageError = normalizePageError(e, meta);
             if (pageError) return pageError;
@@ -179,7 +182,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
             return { error: `API 返回错误: ${httpError.error}` };
         }
 
-        // 6. 解析响应体
+        // 7. 解析响应体
         const bodyBuffer = await apiResponse.body();
         logger.debug('适配器', `收到响应体，字节数: ${bodyBuffer.length}`, meta);
 
@@ -214,9 +217,10 @@ export const manifest = {
     },
 
     models: [
-        { id: 'gemini-3.1-flash', imagePolicy: 'optional', type: 'text' },
-        { id: 'gemini-3.1-flash-thinking', imagePolicy: 'optional', type: 'text' },
-        { id: 'gemini-3.1-pro', imagePolicy: 'optional', type: 'text' }
+        { id: 'gemini-2.0-flash-exp', imagePolicy: 'optional', type: 'text' },
+        { id: 'gemini-exp-1206', imagePolicy: 'optional', type: 'text' },
+        { id: 'gemini-3-pro', imagePolicy: 'optional', type: 'text' },
+        { id: 'gemini-3-flash', imagePolicy: 'optional', type: 'text' }
     ],
 
     navigationHandlers: [],

--- a/src/backend/adapter/lmarena.js
+++ b/src/backend/adapter/lmarena.js
@@ -16,6 +16,7 @@ import {
     gotoWithCheck,
     useContextDownload
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -51,89 +52,88 @@ function extractImage(text) {
  * @returns {Promise<{image?: string, text?: string, error?: string}>} 生成结果
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, config, instanceName } = context;
     const textareaSelector = 'textarea';
 
     try {
-        logger.info('适配器', '开启新会话...', meta);
-        await gotoWithCheck(page, TARGET_URL);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', '开启新会话...', meta);
+            await gotoWithCheck(page, TARGET_URL);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, textareaSelector, { click: true });
+            // 1. 等待输入框加载
+            await waitForInput(page, textareaSelector, { click: true });
 
-        // 2. 选择模型
-        if (modelId) {
-            logger.debug('适配器', `选择模型: ${modelId}`, meta);
-            // 使用键盘导航展开模型选择框：按两次 Shift+Tab 然后 Enter
-            await page.keyboard.down('Shift');
-            await page.keyboard.press('Tab');
-            await page.keyboard.press('Tab');
-            await page.keyboard.up('Shift');
-            await sleep(100, 200);
-            await page.keyboard.press('Enter');
+            // 2. 选择模型
+            if (modelId) {
+                logger.debug('适配器', `选择模型: ${modelId}`, meta);
+                // 使用键盘导航展开模型选择框：按两次 Shift+Tab 然后 Enter
+                await page.keyboard.down('Shift');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.up('Shift');
+                await sleep(100, 200);
+                await page.keyboard.press('Enter');
 
-            // 获取模型配置，优先使用 codeName，否则使用 id
-            const modelConfig = manifest.models.find(m => m.id === modelId);
-            const searchText = modelConfig?.codeName || modelId;
+                // 获取模型配置，优先使用 codeName，否则使用 id
+                const modelConfig = manifest.models.find(m => m.id === modelId);
+                const searchText = modelConfig?.codeName || modelId;
 
-            // 模拟粘贴输入模型名称
-            await page.evaluate((text) => {
-                document.execCommand('insertText', false, text);
-            }, searchText);
+                // 模拟粘贴输入模型名称
+                await page.evaluate((text) => {
+                    document.execCommand('insertText', false, text);
+                }, searchText);
 
-            // 等待过滤完成：第一个选项包含目标模型的主 ID
-            // searchText 可能是 codeName（含括号说明），但过滤后的选项应该包含 modelId
-            try {
-                await page.waitForFunction(
-                    (targetId) => {
-                        const firstOption = document.querySelector('[role="option"]');
-                        return firstOption && firstOption.textContent?.includes(targetId);
-                    },
-                    modelId,
-                    { timeout: 5000 }
-                );
-            } catch {
-                // 超时也继续，可能列表结构不同
-                logger.debug('适配器', `等待模型选项过滤超时，继续执行`, meta);
+                // 等待过滤完成：第一个选项包含目标模型的主 ID
+                try {
+                    await page.waitForFunction(
+                        (targetId) => {
+                            const firstOption = document.querySelector('[role="option"]');
+                            return firstOption && firstOption.textContent?.includes(targetId);
+                        },
+                        modelId,
+                        { timeout: 5000 }
+                    );
+                } catch {
+                    logger.debug('适配器', `等待模型选项过滤超时，继续执行`, meta);
+                }
+                await sleep(300, 500);
+                await page.keyboard.press('Enter');
             }
-            await sleep(300, 500);
-            await page.keyboard.press('Enter');
-        }
 
-        // 3. 上传图片
-        if (imgPaths && imgPaths.length > 0) {
-            logger.info('适配器', `开始上传 ${imgPaths.length} 张图片`, meta);
-            await pasteImages(page, textareaSelector, imgPaths, {}, meta);
-            logger.info('适配器', '图片上传完成', meta);
-        }
+            // 3. 上传图片
+            if (imgPaths && imgPaths.length > 0) {
+                logger.info('适配器', `开始上传 ${imgPaths.length} 张图片`, meta);
+                await pasteImages(page, textareaSelector, imgPaths, {}, meta);
+                logger.info('适配器', '图片上传完成', meta);
+            }
 
-        // 4. 输入提示词
-        await safeClick(page, textareaSelector, { bias: 'input' });
-        logger.info('适配器', '输入提示词...', meta);
-        await humanType(page, textareaSelector, prompt);
+            // 4. 输入提示词
+            await safeClick(page, textareaSelector, { bias: 'input' });
+            logger.info('适配器', '输入提示词...', meta);
+            await humanType(page, textareaSelector, prompt);
 
-        // 5. 先启动 API 监听
+            // 5. 发送提示词（点击后立即释放锁）
+            logger.info('适配器', '发送提示词...', meta);
+            await safeClick(page, 'button[type="submit"]', { bias: 'button' });
+
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 6. 等待 API 响应（不需要锁，可以并行）
         logger.debug('适配器', '启动 API 监听...', meta);
-        const responsePromise = waitApiResponse(page, {
-            urlMatch: '/nextjs-api/stream',
-            method: 'POST',
-            timeout: waitTimeout,
-            meta
-        });
-
-        // 6. 发送提示词
-        logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, 'button[type="submit"]', { bias: 'button' });
-
         logger.info('适配器', '等待生成结果...', meta);
 
-        // 7. 等待 API 响应
         let response;
         try {
-            response = await responsePromise;
+            response = await waitApiResponse(page, {
+                urlMatch: '/nextjs-api/stream',
+                method: 'POST',
+                timeout: 120000,
+                meta
+            });
         } catch (e) {
-            // 使用公共错误处理
             const pageError = normalizePageError(e, meta);
             if (pageError) return pageError;
             throw e;
@@ -160,10 +160,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
             }
 
             logger.info('适配器', '已获取结果，正在下载图片...', meta);
-            const imgDlCfg = config?.backend?.pool?.failover || {};
-            const result = await useContextDownload(img, page, {
-                retries: imgDlCfg.imgDlRetry ? (imgDlCfg.imgDlRetryMaxRetries || 2) : 0
-            });
+            const result = await useContextDownload(img, page);
             if (result.image) {
                 logger.info('适配器', '已下载图片，任务完成', meta);
             }

--- a/src/backend/adapter/lmarena_text.js
+++ b/src/backend/adapter/lmarena_text.js
@@ -15,6 +15,7 @@ import {
     waitForInput,
     gotoWithCheck
 } from '../utils/index.js';
+import { withUILock } from '../utils/uiLock.js';
 import { logger } from '../../utils/logger.js';
 
 // --- 配置常量 ---
@@ -31,8 +32,7 @@ const TARGET_URL_SEARCH = 'https://lmarena.ai/zh/c/new?mode=direct&chat-modality
  * @returns {Promise<{image?: string, text?: string, error?: string}>} 生成结果
  */
 async function generate(context, prompt, imgPaths, modelId, meta = {}) {
-    const { page, config } = context;
-    const waitTimeout = config?.backend?.pool?.waitTimeout ?? 120000;
+    const { page, instanceName } = context;
     const textareaSelector = 'textarea';
 
     // Worker 已验证，直接解析模型配置
@@ -41,81 +41,84 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
     const targetUrl = search ? TARGET_URL_SEARCH : TARGET_URL;
 
     try {
-        logger.info('适配器', `开启新会话... (搜索模式: ${!!search})`, meta);
-        await gotoWithCheck(page, targetUrl);
+        // === UI 交互阶段：需要加锁 ===
+        await withUILock(instanceName, async () => {
+            logger.info('适配器', `开启新会话... (搜索模式: ${!!search})`, meta);
+            await gotoWithCheck(page, targetUrl);
 
-        // 1. 等待输入框加载
-        await waitForInput(page, textareaSelector, { click: false });
+            // 1. 等待输入框加载
+            await waitForInput(page, textareaSelector, { click: false });
 
-        // 2. 选择模型
-        if (modelId) {
-            logger.debug('适配器', `选择模型: ${modelId}`, meta);
-            // 使用键盘导航展开模型选择框：按两次 Shift+Tab 然后 Enter
-            await page.keyboard.down('Shift');
-            await page.keyboard.press('Tab');
-            await page.keyboard.press('Tab');
-            await page.keyboard.up('Shift');
-            await sleep(100, 200);
-            await page.keyboard.press('Enter');
+            // 2. 选择模型
+            if (modelId) {
+                logger.debug('适配器', `选择模型: ${modelId}`, meta);
+                // 使用键盘导航展开模型选择框：按两次 Shift+Tab 然后 Enter
+                await page.keyboard.down('Shift');
+                await page.keyboard.press('Tab');
+                await page.keyboard.press('Tab');
+                await page.keyboard.up('Shift');
+                await sleep(100, 200);
+                await page.keyboard.press('Enter');
 
-            // 获取模型配置，优先使用 codeName，否则使用 id
-            const searchText = modelConfig?.codeName || modelId;
+                // 获取模型配置，优先使用 codeName，否则使用 id
+                const searchText = modelConfig?.codeName || modelId;
 
-            // 模拟粘贴输入模型名称
-            await page.evaluate((text) => {
-                document.execCommand('insertText', false, text);
-            }, searchText);
+                // 模拟粘贴输入模型名称
+                await page.evaluate((text) => {
+                    document.execCommand('insertText', false, text);
+                }, searchText);
 
-            // 等待过滤完成：第一个选项包含目标模型的主 ID
-            // searchText 可能是 codeName（含括号说明），但过滤后的选项应该包含 modelId
-            try {
-                await page.waitForFunction(
-                    (targetId) => {
-                        const firstOption = document.querySelector('[role="option"]');
-                        return firstOption && firstOption.textContent?.includes(targetId);
-                    },
-                    modelId,
-                    { timeout: 5000 }
-                );
-            } catch {
-                // 超时也继续，可能列表结构不同
-                logger.debug('适配器', `等待模型选项过滤超时，继续执行`, meta);
+                // 等待过滤完成：第一个选项包含目标模型的主 ID
+                // searchText 可能是 codeName（含括号说明），但过滤后的选项应该包含 modelId
+                try {
+                    await page.waitForFunction(
+                        (targetId) => {
+                            const firstOption = document.querySelector('[role="option"]');
+                            return firstOption && firstOption.textContent?.includes(targetId);
+                        },
+                        modelId,
+                        { timeout: 5000 }
+                    );
+                } catch {
+                    // 超时也继续，可能列表结构不同
+                    logger.debug('适配器', `等待模型选项过滤超时，继续执行`, meta);
+                }
+                await sleep(300, 500);
+                await page.keyboard.press('Enter');
             }
-            await sleep(300, 500);
-            await page.keyboard.press('Enter');
-        }
 
-        // 3. 上传图片
-        if (imgPaths && imgPaths.length > 0) {
-            logger.info('适配器', `开始上传 ${imgPaths.length} 张图片`, meta);
-            await pasteImages(page, textareaSelector, imgPaths, {}, meta);
-            logger.info('适配器', '图片上传完成', meta);
-        }
+            // 3. 上传图片
+            if (imgPaths && imgPaths.length > 0) {
+                logger.info('适配器', `开始上传 ${imgPaths.length} 张图片`, meta);
+                await pasteImages(page, textareaSelector, imgPaths, {}, meta);
+                logger.info('适配器', '图片上传完成', meta);
+            }
 
-        // 4. 填写提示词
-        await safeClick(page, textareaSelector, { bias: 'input' });
-        logger.info('适配器', '输入提示词...', meta);
-        await humanType(page, textareaSelector, prompt);
+            // 4. 填写提示词
+            await safeClick(page, textareaSelector, { bias: 'input' });
+            logger.info('适配器', '输入提示词...', meta);
+            await humanType(page, textareaSelector, prompt);
 
-        // 5. 先启动 API 监听
+            // 5. 发送提示词（点击后立即释放锁）
+            logger.info('适配器', '发送提示词...', meta);
+            await safeClick(page, 'button[type="submit"]', { bias: 'button' });
+
+            // 锁在这里释放，其他请求可以开始 UI 交互了
+        }, meta);
+        // === UI 交互阶段结束，锁已释放 ===
+
+        // 6. 等待 API 响应（不需要锁，可以并行）
         logger.debug('适配器', '启动 API 监听...', meta);
-        const responsePromise = waitApiResponse(page, {
-            urlMatch: '/nextjs-api/stream',
-            method: 'POST',
-            timeout: waitTimeout,
-            meta
-        });
-
-        // 6. 发送提示词
-        logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, 'button[type="submit"]', { bias: 'button' });
-
         logger.info('适配器', '等待生成结果...', meta);
 
-        // 7. 等待 API 响应
         let response;
         try {
-            response = await responsePromise;
+            response = await waitApiResponse(page, {
+                urlMatch: '/nextjs-api/stream',
+                method: 'POST',
+                timeout: 120000,
+                meta
+            });
         } catch (e) {
             // 使用公共错误处理
             const pageError = normalizePageError(e, meta);

--- a/src/backend/pool/Worker.js
+++ b/src/backend/pool/Worker.js
@@ -476,7 +476,8 @@ export class Worker {
             page: this.page,
             config: this.globalConfig,
             proxyConfig: this.proxyConfig,
-            userDataDir: this.userDataDir
+            userDataDir: this.userDataDir,
+            instanceName: this.instanceName  // 用于 UI 锁
         };
 
         this.busyCount++;

--- a/src/backend/utils/uiLock.js
+++ b/src/backend/utils/uiLock.js
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview UI 交互锁模块
+ * @description 用于解决同一浏览器实例下多 Worker 并发 UI 操作的冲突问题
+ *
+ * 问题背景：
+ * - WebAI2API 使用 ghost-cursor 模拟拟人化鼠标轨迹
+ * - 同一浏览器实例下多个 Worker 并发操作时，鼠标移动和点击会相互干扰
+ * - 导致 CLICK_TIMEOUT 等错误
+ *
+ * 解决方案：
+ * - 在 UI 交互阶段（输入、点击）加锁，确保同一时间只有一个 Worker 进行 UI 操作
+ * - 生成/等待响应阶段不需要锁，可以并行执行
+ */
+
+import { logger } from '../../utils/logger.js';
+
+/**
+ * 简单的异步互斥锁实现
+ */
+class AsyncMutex {
+    constructor() {
+        this._locked = false;
+        this._waiting = [];
+    }
+
+    /**
+     * 获取锁
+     * @returns {Promise<void>}
+     */
+    async acquire() {
+        if (!this._locked) {
+            this._locked = true;
+            return;
+        }
+
+        // 已被锁定，加入等待队列
+        return new Promise(resolve => {
+            this._waiting.push(resolve);
+        });
+    }
+
+    /**
+     * 释放锁
+     */
+    release() {
+        if (this._waiting.length > 0) {
+            // 唤醒下一个等待者
+            const next = this._waiting.shift();
+            next();
+        } else {
+            this._locked = false;
+        }
+    }
+
+    /**
+     * 检查是否被锁定
+     * @returns {boolean}
+     */
+    isLocked() {
+        return this._locked;
+    }
+}
+
+// 每个浏览器实例一个锁
+const instanceLocks = new Map();
+
+/**
+ * 获取指定实例的 UI 锁
+ * @param {string} instanceName - 浏览器实例名称
+ * @returns {AsyncMutex}
+ */
+function getInstanceLock(instanceName) {
+    const key = instanceName || 'default';
+    if (!instanceLocks.has(key)) {
+        instanceLocks.set(key, new AsyncMutex());
+    }
+    return instanceLocks.get(key);
+}
+
+/**
+ * 在持有 UI 锁的情况下执行操作
+ * @param {string} instanceName - 浏览器实例名称
+ * @param {Function} fn - 要执行的异步函数
+ * @param {object} [meta={}] - 日志元数据
+ * @returns {Promise<any>} 执行结果
+ */
+export async function withUILock(instanceName, fn, meta = {}) {
+    const lock = getInstanceLock(instanceName);
+    const key = instanceName || 'default';
+
+    if (lock.isLocked()) {
+        logger.debug('UI锁', `[${key}] 等待获取锁...`, meta);
+    }
+
+    await lock.acquire();
+    logger.debug('UI锁', `[${key}] 已获取锁`, meta);
+
+    try {
+        return await fn();
+    } finally {
+        lock.release();
+        logger.debug('UI锁', `[${key}] 已释放锁`, meta);
+    }
+}
+
+/**
+ * 清理指定实例的锁（用于实例销毁时）
+ * @param {string} instanceName - 浏览器实例名称
+ */
+export function clearInstanceLock(instanceName) {
+    const key = instanceName || 'default';
+    instanceLocks.delete(key);
+}
+
+export { getInstanceLock, AsyncMutex };


### PR DESCRIPTION
## Summary

- 新增 UI Lock 机制，解决同一浏览器实例下多 Worker 并发 UI 操作的冲突问题
- 当多个请求共享同一浏览器实例时，确保 UI 交互阶段（导航、输入、点击）串行执行
- SSE 响应等待阶段不加锁，可以并行执行，提高并发效率

## 改动详情

- 新增 `src/backend/utils/uiLock.js` 提供 `withUILock()` 包装函数
- `Worker.js` 传递 `instanceName` 到适配器 context
- 为 7 个适配器添加 UI Lock 支持:
  - `chatgpt.js`, `chatgpt_text.js`
  - `deepseek_text.js`
  - `gemini.js`, `gemini_text.js`
  - `lmarena.js`, `lmarena_text.js`

## 设计原理

```
时间线 →（流式响应持续 30 秒）

Before (无 UI Lock):
Worker1: [==UI==][==========等待流式响应==========]
Worker2:    [==UI==][==========等待流式响应==========]  ← UI 操作冲突!

After (有 UI Lock):
Worker1: [==UI==][==========流式响应 30s==========]
Worker2:    [等待锁...][==UI==][==========流式响应==========]
                 ↑ UI 操作串行，响应等待并行
```

## 测试

- ✅ 单请求测试通过
- ✅ 并发请求测试通过（UI Lock 正常工作）
- ✅ 所有适配器语法检查通过

## 关联 Issue

解决并发请求时可能出现的 `CLICK_TIMEOUT` 错误