### PR TITLE
feat: 支持 reasoning 输出与日志前缀增强

### DIFF
--- a/src/server/respond.js
+++ b/src/server/respond.js
@@ -106,9 +106,20 @@ export function sendApiError(res, options) {
  * 构造 OpenAI 格式的聊天完成响应（非流式）
  * @param {string} content - 响应内容
  * @param {string} [modelName] - 模型名称
+ * @param {string} [reasoningContent] - 思考/推理过程内容 (OpenAI o1 格式)
  * @returns {object} OpenAI 格式的响应对象
  */
-export function buildChatCompletion(content, modelName) {
+export function buildChatCompletion(content, modelName, reasoningContent) {
+    const message = {
+        role: 'assistant',
+        content: content
+    };
+
+    // 如果有思考过程，添加 reasoning_content 字段 (OpenAI o1 兼容格式)
+    if (reasoningContent) {
+        message.reasoning_content = reasoningContent;
+    }
+
     return {
         id: 'chatcmpl-' + Date.now(),
         object: 'chat.completion',
@@ -116,10 +127,7 @@ export function buildChatCompletion(content, modelName) {
         model: modelName || 'default-model',
         choices: [{
             index: 0,
-            message: {
-                role: 'assistant',
-                content: content
-            },
+            message,
             finish_reason: 'stop'
         }]
     };
@@ -130,9 +138,17 @@ export function buildChatCompletion(content, modelName) {
  * @param {string} content - 响应内容
  * @param {string} [modelName] - 模型名称
  * @param {string|null} [finishReason='stop'] - 完成原因
+ * @param {string} [reasoningContent] - 思考/推理过程内容 (OpenAI o1 格式)
  * @returns {object} OpenAI 格式的流式响应块
  */
-export function buildChatCompletionChunk(content, modelName, finishReason = 'stop') {
+export function buildChatCompletionChunk(content, modelName, finishReason = 'stop', reasoningContent) {
+    const delta = { content };
+
+    // 如果有思考过程，添加 reasoning_content 字段
+    if (reasoningContent) {
+        delta.reasoning_content = reasoningContent;
+    }
+
     return {
         id: 'chatcmpl-' + Date.now(),
         object: 'chat.completion.chunk',
@@ -140,7 +156,7 @@ export function buildChatCompletionChunk(content, modelName, finishReason = 'sto
         model: modelName || 'default-model',
         choices: [{
             index: 0,
-            delta: { content },
+            delta,
             finish_reason: finishReason
         }]
     };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -112,6 +112,9 @@ function shouldLog(level) {
     return targetIndex >= effectiveEnvIndex;
 }
 
+// 需要提取到前面用方括号显示的 meta 字段
+const FRONT_META_KEYS = ['id', 'adapter', 'model'];
+
 export function log(level, mod, msg, meta = {}) {
     if (!shouldLog(level)) return;
 
@@ -121,10 +124,23 @@ export function log(level, mod, msg, meta = {}) {
 
     // 将消息中的换行符替换为 ↵ 符号，保持日志为单行
     const sanitizedMsg = msg.replace(/\r?\n/g, ' ↵ ');
-    const base = `${ts} [${levelTag}] [${mod}] ${sanitizedMsg}`;
 
-    const metaStr = Object.keys(meta).length
-        ? ' | ' + Object.entries(meta).map(([k, v]) => {
+    // 提取关键字段放在前面用方括号显示
+    const frontParts = [];
+    const remainingMeta = {};
+    for (const [k, v] of Object.entries(meta)) {
+        if (FRONT_META_KEYS.includes(k) && v !== undefined && v !== null) {
+            frontParts.push(`[${v}]`);
+        } else {
+            remainingMeta[k] = v;
+        }
+    }
+    const frontStr = frontParts.length ? ' ' + frontParts.join(' ') : '';
+
+    const base = `${ts} [${levelTag}] [${mod}]${frontStr} ${sanitizedMsg}`;
+
+    const metaStr = Object.keys(remainingMeta).length
+        ? ' | ' + Object.entries(remainingMeta).map(([k, v]) => {
             if (v instanceof Error) {
                 return `${k}=${v.message}`;
             }


### PR DESCRIPTION
## Summary
- **respond.js**: `buildChatCompletion` 和 `buildChatCompletionChunk` 新增 `reasoningContent` 参数，输出 OpenAI o1 兼容的 `reasoning_content` 字段。修复 `queue.js` 已传入 `reasoningContent` 但响应构建函数未接收使用的问题。
- **logger.js**: 日志前缀自动提取 meta 中的 `id`/`adapter`/`model` 字段用方括号显示（如 `[req-123] [chatgpt] [gpt-4]`），其余 meta 仍以 `k=v` 形式追加，提升日志可读性。

## Test plan
- [ ] 使用支持 thinking/reasoning 的模型（如 LMArena claude-opus-4-6-thinking）发起请求，验证非流式和流式响应中 `reasoning_content` 字段正确输出
- [ ] 检查日志输出格式，确认 id/adapter/model 以方括号前缀显示