### PR TITLE
Fix Gemini send and ChatGPT final response handling

### DIFF
--- a/src/backend/adapter/chatgpt_text.js
+++ b/src/backend/adapter/chatgpt_text.js
@@ -28,17 +28,27 @@ const INPUT_SELECTOR = '.ProseMirror';
  */
 async function selectModel(page, codeName, meta = {}) {
     try {
-        // 1. 点击 Model selector 按钮
-        const modelSelectorBtn = page.getByRole('button', { name: /^Model selector/ });
-        const btnExists = await modelSelectorBtn.count();
-        if (btnExists === 0) {
-            logger.debug('适配器', '未找到模型选择器按钮，跳过选择模型', meta);
+        // 1. 点击模型选择按钮。ChatGPT 网页经常改 aria-label，优先用 data-testid，再回退到可见文本。
+        const candidates = [
+            page.locator('[data-testid="model-switcher-dropdown-button"]'),
+            page.getByRole('button', { name: /Model selector|models?|ChatGPT|GPT|Instant|Thinking|Pro/i }),
+            page.locator('button').filter({ hasText: /ChatGPT|GPT|Instant|Thinking|Pro/i })
+        ];
+        let modelSelectorBtn = null;
+        for (const candidate of candidates) {
+            if (await candidate.count().catch(() => 0)) {
+                modelSelectorBtn = candidate.first();
+                break;
+            }
+        }
+        if (!modelSelectorBtn) {
+            logger.warn('适配器', '未找到模型选择器按钮，跳过选择模型', meta);
             return false;
         }
 
         await modelSelectorBtn.waitFor({ timeout: 5000 });
         await safeClick(page, modelSelectorBtn, { bias: 'button' });
-        await sleep(300, 500);
+        await sleep(500, 800);
 
         // 2. 检查是否有 Legacy models 选项
         const legacyMenuItem = page.getByRole('menuitem', { name: /^Legacy models/ });
@@ -239,6 +249,91 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
             const pageError = normalizePageError(e, meta);
             if (pageError) return pageError;
             throw e;
+        }
+
+        if (!textContent || textContent.trim() === '') {
+            logger.warn('适配器', 'SSE 未解析到文本，尝试 DOM 回退提取...', meta);
+            try {
+                const domWaitTimeout = Math.min(waitTimeout, 60000);
+                const extractAssistantText = () => {
+                    const rejectExact = new Set(['Thinking', 'Instant', 'Pro', 'ChatGPT']);
+                    const clean = (value) => (value || '')
+                        .replace(/^ChatGPT said:\s*/i, '')
+                        .replace(/\u00a0/g, ' ')
+                        .trim();
+                    const acceptable = (value) => {
+                        const text = clean(value);
+                        if (!text || rejectExact.has(text)) return '';
+                        if (/^(Thinking|Instant|Pro)\s*$/i.test(text)) return '';
+                        if (/^\d+\s*\/\s*\d+$/.test(text)) return '';
+                        return text;
+                    };
+
+                    const nodes = Array.from(document.querySelectorAll('[data-message-author-role="assistant"]'));
+                    for (let i = nodes.length - 1; i >= 0; i--) {
+                        const node = nodes[i];
+                        const preferred = Array.from(node.querySelectorAll('.markdown, .prose, [data-message-content-part]'));
+                        for (let j = preferred.length - 1; j >= 0; j--) {
+                            const text = acceptable(preferred[j].innerText || preferred[j].textContent);
+                            if (text) return text;
+                        }
+
+                        const lines = clean(node.innerText || node.textContent)
+                            .split('\n')
+                            .map(line => clean(line))
+                            .filter(Boolean)
+                            .filter(line => !rejectExact.has(line));
+                        const text = acceptable(lines.join('\n'));
+                        if (text) return text;
+                    }
+                    return '';
+                };
+
+                const isGenerating = () => {
+                    const text = document.body.innerText || '';
+                    if (/Thinking\.\.\.|Thinking…|正在思考|思考中/.test(text)) return true;
+                    const buttons = Array.from(document.querySelectorAll('button'));
+                    return buttons.some((button) => {
+                        const label = `${button.getAttribute('aria-label') || ''} ${button.innerText || button.textContent || ''}`;
+                        return /stop generating|stop streaming|停止生成|停止回答|cancel/i.test(label);
+                    });
+                };
+
+                await page.waitForFunction(extractAssistantText, null, { timeout: domWaitTimeout }).catch(() => { });
+
+                let domText = '';
+                let lastText = '';
+                let stableCount = 0;
+                const stableStartedAt = Date.now();
+                while (Date.now() - stableStartedAt < domWaitTimeout) {
+                    const currentText = await page.evaluate(extractAssistantText);
+                    const generating = await page.evaluate(isGenerating).catch(() => false);
+                    if (currentText && currentText === lastText && !generating) {
+                        stableCount++;
+                    } else {
+                        stableCount = 0;
+                        lastText = currentText || lastText || '';
+                    }
+
+                    if (lastText && !generating && stableCount >= 8) {
+                        domText = lastText;
+                        break;
+                    }
+
+                    await sleep(1200, 1600);
+                }
+
+                if (!domText) {
+                    domText = lastText || await page.evaluate(extractAssistantText);
+                }
+
+                if (domText && domText.trim()) {
+                    textContent = domText.trim();
+                    logger.info('适配器', `DOM 回退提取文本成功 (${textContent.length} 字符)`, meta);
+                }
+            } catch (e) {
+                logger.warn('适配器', `DOM 回退提取失败: ${e.message}`, meta);
+            }
         }
 
         if (!textContent || textContent.trim() === '') {

--- a/src/backend/adapter/gemini.js
+++ b/src/backend/adapter/gemini.js
@@ -21,6 +21,39 @@ import { logger } from '../../utils/logger.js';
 // --- 配置常量 ---
 const TARGET_URL = 'https://gemini.google.com/app?hl=en';
 
+async function clickGeminiSend(page, inputLocator, sendBtnLocator, meta = {}) {
+    const waitForEnabled = async (locator, timeout = 5000) => {
+        await locator.waitFor({ state: 'visible', timeout });
+        const started = Date.now();
+        while (Date.now() - started < timeout) {
+            if (await locator.isEnabled().catch(() => false)) return;
+            await sleep(100, 150);
+        }
+        throw new Error('send button disabled');
+    };
+
+    const candidates = [
+        sendBtnLocator.last(),
+        page.getByRole('button', { name: /send message|send|submit/i }).last(),
+        page.locator('button[aria-label*="Send"], button[aria-label*="Submit"]').last(),
+        page.locator('button:has(mat-icon)').filter({ hasText: /send/i }).last()
+    ];
+
+    for (const locator of candidates) {
+        try {
+            await waitForEnabled(locator);
+            await locator.click({ force: true, timeout: 5000 });
+            return;
+        } catch (e) {
+            logger.debug('适配器', `发送按钮点击候选失败: ${e.message}`, meta);
+        }
+    }
+
+    logger.warn('适配器', '发送按钮点击失败，尝试键盘 Enter 发送', meta);
+    await safeClick(page, inputLocator, { bias: 'input', timeout: 5000 });
+    await page.keyboard.press('Enter');
+}
+
 
 /**
  * 执行生图任务
@@ -120,7 +153,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
 
         // 7. 发送提示词
         logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
+        await clickGeminiSend(page, inputLocator, sendBtnLocator, meta);
 
         logger.info('适配器', '等待生成结果...', meta);
 

--- a/src/backend/adapter/gemini_text.js
+++ b/src/backend/adapter/gemini_text.js
@@ -20,6 +20,39 @@ import { logger } from '../../utils/logger.js';
 // --- 配置常量 ---
 const TARGET_URL = 'https://gemini.google.com/app?hl=en';
 
+async function clickGeminiSend(page, inputLocator, sendBtnLocator, meta = {}) {
+    const waitForEnabled = async (locator, timeout = 5000) => {
+        await locator.waitFor({ state: 'visible', timeout });
+        const started = Date.now();
+        while (Date.now() - started < timeout) {
+            if (await locator.isEnabled().catch(() => false)) return;
+            await sleep(100, 150);
+        }
+        throw new Error('send button disabled');
+    };
+
+    const candidates = [
+        sendBtnLocator.last(),
+        page.getByRole('button', { name: /send message|send|submit/i }).last(),
+        page.locator('button[aria-label*="Send"], button[aria-label*="Submit"]').last(),
+        page.locator('button:has(mat-icon)').filter({ hasText: /send/i }).last()
+    ];
+
+    for (const locator of candidates) {
+        try {
+            await waitForEnabled(locator);
+            await locator.click({ force: true, timeout: 5000 });
+            return;
+        } catch (e) {
+            logger.debug('适配器', `发送按钮点击候选失败: ${e.message}`, meta);
+        }
+    }
+
+    logger.warn('适配器', '发送按钮点击失败，尝试键盘 Enter 发送', meta);
+    await safeClick(page, inputLocator, { bias: 'input', timeout: 5000 });
+    await page.keyboard.press('Enter');
+}
+
 /**
  * 执行文本生成任务
  * @param {object} context - 浏览器上下文 { page, config }
@@ -158,7 +191,7 @@ async function generate(context, prompt, imgPaths, modelId, meta = {}) {
 
         // 6. 发送提示词
         logger.info('适配器', '发送提示词...', meta);
-        await safeClick(page, sendBtnLocator, { bias: 'button' });
+        await clickGeminiSend(page, inputLocator, sendBtnLocator, meta);
 
         logger.info('适配器', '等待生成结果...', meta);
 


### PR DESCRIPTION
## Summary

- Make Gemini send-button handling more resilient when the current web UI no longer exposes or enables the old `Send message` button as expected.
- Add fallback candidates and an Enter-key fallback for Gemini text/image adapters.
- Make ChatGPT model selector lookup tolerate the current `data-testid`/visible-label based selector button.
- Add a ChatGPT DOM fallback that waits until generation appears finished and text is stable before returning, avoiding early outline/intermediate text being treated as the final answer when SSE parsing does not yield content.

## Validation

- `node --check src/backend/adapter/gemini_text.js`
- `node --check src/backend/adapter/gemini.js`
- `node --check src/backend/adapter/chatgpt_text.js`
- `git diff --check`
- Verified the same fixes in a running Docker deployment: Gemini text requests returned final text instead of timing out, and ChatGPT Pro returned the final answer instead of the initial outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
